### PR TITLE
feat(generate): return both HCL and YAML as tuple in generate and gen…

### DIFF
--- a/generator/main.py
+++ b/generator/main.py
@@ -72,7 +72,7 @@ def main(args=None):
         f"{tempdir}/{'' if args.path is None else args.path}"
     )
 
-    output: str = generate(
+    output, yanl = generate(
         args.url,
         None if args.path is None else args.path,
         args.version,
@@ -101,3 +101,4 @@ def main(args=None):
         print(f"terragrunt.hcl written to: {output_path}")
     else:
         print(output)
+        # print(yanl)

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -20,7 +20,7 @@ def test_generate_header():
         'optionals': [{'name': 'optionals', 'description': 'optionals'}],
         'nullables': [{'name': 'nullables', 'description': 'nullables'}],
     }
-    results = generate_header(name, url, path, version, lookup, variables)
+    results, yaml = generate_header(name, url, path, version, lookup, variables)
 
     print(results)
 
@@ -42,6 +42,7 @@ def test_generate_header():
 """
     assert results == expected
 
+
 def test_generate_header_with_deep_lookup():
     url: str = 'https://gitserver.com/test/test.git'
     path: str = 'modules/test'
@@ -53,7 +54,7 @@ def test_generate_header_with_deep_lookup():
         'optionals': [{'name': 'optionals', 'description': 'optionals'}],
         'nullables': [{'name': 'nullables', 'description': 'nullables'}],
     }
-    results = generate_header(name, url, path, version, lookup, variables)
+    results, yaml = generate_header(name, url, path, version, lookup, variables)
 
     print(results)
 
@@ -88,7 +89,7 @@ def test_generate_header_local_module():
         'optionals': [{'name': 'optionals', 'description': 'optionals'}],
         'nullables': [{'name': 'nullables', 'description': 'nullables'}],
     }
-    results = generate_header(name, url, path, version, lookup, variables)
+    results, yaml = generate_header(name, url, path, version, lookup, variables)
     excepted = """# test 0.1.0
 # ./test/test/
 #
@@ -119,7 +120,7 @@ def test_generate_header_module():
         'optionals': [{'name': 'optionals', 'description': 'optionals'}],
         'nullables': [{'name': 'nullables', 'description': 'nullables'}],
     }
-    results = generate_header(name, url, path, version, lookup, variables)
+    results, yaml = generate_header(name, url, path, version, lookup, variables)
     excepted = """# test 0.1.0
 # https://gitserver.com/test/test/tree/0.1.0/
 #
@@ -150,7 +151,7 @@ def test_generate_header_submodule():
         'optionals': [{'name': 'optionals', 'description': 'optionals'}],
         'nullables': [{'name': 'nullables', 'description': 'nullables'}],
     }
-    results = generate_header(name, url, path, version, lookup, variables)
+    results, yaml = generate_header(name, url, path, version, lookup, variables)
     excepted = """# test 0.1.0
 # https://gitserver.com/test/test/tree/0.1.0/modules/test
 #
@@ -181,7 +182,7 @@ def test_generate_header_nested_lookup():
         'optionals': [{'name': 'optionals', 'description': 'optionals'}],
         'nullables': [{'name': 'nullables', 'description': 'nullables'}],
     }
-    results = generate_header(name, url, path, version, lookup, variables)
+    results, yaml = generate_header(name, url, path, version, lookup, variables)
     excepted = """# test 0.1.0
 # https://gitserver.com/test/test/tree/0.1.0/modules/test
 #
@@ -446,7 +447,7 @@ def test_generate():
         ]
     }
 
-    results = generate(
+    results, yaml = generate(
         url,
         path,
         version,
@@ -532,7 +533,7 @@ inputs = merge({
         ]
     }
 
-    results = generate(
+    results, yaml = generate(
         url,
         path,
         version,
@@ -617,7 +618,7 @@ inputs = merge({
         ]
     }
 
-    results = generate(
+    results, yaml = generate(
         url,
         path,
         version,
@@ -704,7 +705,7 @@ inputs = merge({
         ]
     }
 
-    results = generate(
+    results, yaml = generate(
         url,
         path,
         version,


### PR DESCRIPTION
…erate_header

- Updated `generate_header` to return a tuple (header_str, yaml_str)
- Updated `generate` to return a tuple (output_str, yaml_str)
- Enables downstream consumers (e.g., CLI, API) to extract raw YAML config independently
- No breaking changes to existing HCL generation logic