### PR TITLE
feat(cli): allow overriding default config filename via CLI

### DIFF
--- a/generator/generate.py
+++ b/generator/generate.py
@@ -66,6 +66,7 @@ def generate_locals(
     url: str = None,
     path: str = None,
     version: str = None,
+    config_filename: str = "config.yaml",
 ) -> str:
     return f"""
 locals {{
@@ -73,7 +74,7 @@ locals {{
         f'"{url.replace("https://", "").replace("http://", "")}{f"//{path}" if path is not None else ""}?ref={version}"' if "http" in url else f'find_in_parent_folders("{url}")'
     }
     all = merge(
-        yamldecode(file(find_in_parent_folders("config.yaml"))),
+        yamldecode(file(find_in_parent_folders("{config_filename}"))),
     )
 }}
 """
@@ -200,6 +201,7 @@ def generate(
     hcl_files: list,
     include: bool = True,
     name: str = None,
+    config_filename: str = "config.yaml",
 ) -> tuple[str, str]:
     variables, variables_object = parse_variables(hcl_files['variable'])
 
@@ -215,7 +217,7 @@ def generate(
         header  # generate_header(name, url, path, version, lookup, variables_object)
     )
     results += generate_include(include)
-    results += generate_locals(url, path, version)
+    results += generate_locals(url, path, version, config_filename)
     results += generate_terraform(url, path, version, lookup)
     results += generate_inputs(variables, lookup)
     return results, yaml

--- a/generator/main.py
+++ b/generator/main.py
@@ -80,12 +80,17 @@ def main(args=None):
     )
 
     output, yanl = generate(
-        args.url,
-        None if args.path is None else args.path,
-        args.version,
-        args.lookup,
-        hcl_files,
-        args.include,
+        url=args.url,
+        path=None if args.path is None else args.path,
+        version=args.version,
+        lookup=args.lookup,
+        hcl_files=hcl_files,
+        include=args.include,
+        config_filename=(
+            os.path.basename(args.yaml_output)
+            if args.yaml_output is not None
+            else "config.yaml"
+        ),
     )
 
     if args.yaml_output is not None:


### PR DESCRIPTION
- Added `config_filename` parameter to `generate` and `generate_locals` functions
- CLI now infers config filename from `--yaml_output` if provided, else defaults to "config.yaml"