### PR TITLE
feat: support YAML config file per environment with --yaml-for-env

### DIFF
--- a/generator/generate.py
+++ b/generator/generate.py
@@ -67,14 +67,23 @@ def generate_locals(
     path: str = None,
     version: str = None,
     config_filename: str = "config.yaml",
+    yaml_env: str = None,
 ) -> str:
+    config_line = (
+        'format("config.%s.yaml", local.environment)'
+        if yaml_env
+        else f'"{config_filename}"'
+    )
+
+    env_line = f'environment = get_env("ENV", "{yaml_env}")\n    ' if yaml_env else ''
+
     return f"""
 locals {{
-    source = {
+    {env_line}source = {
         f'"{url.replace("https://", "").replace("http://", "")}{f"//{path}" if path is not None else ""}?ref={version}"' if "http" in url else f'find_in_parent_folders("{url}")'
     }
     all = merge(
-        yamldecode(file(find_in_parent_folders("{config_filename}"))),
+        yamldecode(file(find_in_parent_folders({config_line}))),
     )
 }}
 """
@@ -202,6 +211,7 @@ def generate(
     include: bool = True,
     name: str = None,
     config_filename: str = "config.yaml",
+    yaml_env: str = None,
 ) -> tuple[str, str]:
     variables, variables_object = parse_variables(hcl_files['variable'])
 
@@ -217,7 +227,7 @@ def generate(
         header  # generate_header(name, url, path, version, lookup, variables_object)
     )
     results += generate_include(include)
-    results += generate_locals(url, path, version, config_filename)
+    results += generate_locals(url, path, version, config_filename, yaml_env)
     results += generate_terraform(url, path, version, lookup)
     results += generate_inputs(variables, lookup)
     return results, yaml

--- a/generator/main.py
+++ b/generator/main.py
@@ -51,6 +51,12 @@ parser.add_argument(
     default=None,
 )
 
+parser.add_argument(
+    '--yaml-for-env',
+    help='Environment name for YAML file like config.<env>.yaml',
+    default=None,
+)
+
 
 def create_working_directory() -> str:
     tempdir = f'{gettempdir()}/{uuid4()}'
@@ -86,31 +92,61 @@ def main(args=None):
         lookup=args.lookup,
         hcl_files=hcl_files,
         include=args.include,
+        # config_filename=(
+        #     os.path.basename(args.yaml_output)
+        #     if args.yaml_output is not None
+        #     else "config.yaml"
+        # ),
         config_filename=(
-            os.path.basename(args.yaml_output)
-            if args.yaml_output is not None
-            else "config.yaml"
+            f"config.{args.yaml_for_env}.yaml"
+            if args.yaml_for_env
+            else (
+                os.path.basename(args.yaml_output)
+                if args.yaml_output is not None
+                else "config.yaml"
+            )
         ),
+        yaml_env=args.yaml_for_env,
     )
 
     if args.yaml_output is not None:
+        config_filename = (
+            f"config.{args.yaml_for_env}.yaml" if args.yaml_for_env else "config.yaml"
+        )
+        yaml_output_path = os.path.join(args.yaml_output, config_filename)
 
-        # Merge si le fichier existe
-        if os.path.exists(args.yaml_output):
-            with open(args.yaml_output, 'r') as f:
+        if os.path.exists(yaml_output_path):
+            with open(yaml_output_path, 'r') as f:
                 existing_yaml = f.read()
             final_yaml = merge_yaml_strings(existing_yaml, yanl)
         else:
             final_yaml = yanl
 
-        output_dir = os.path.dirname(args.yaml_output)
-        if output_dir:
-            os.makedirs(output_dir, exist_ok=True)
+        os.makedirs(os.path.dirname(yaml_output_path), exist_ok=True)
 
-        with open(args.yaml_output, 'w') as f:
+        with open(yaml_output_path, 'w') as f:
             f.write(final_yaml)
 
-        print(f"YAML config written to: {args.yaml_output}")
+        print(f"YAML config written to: {yaml_output_path}")
+
+    #    if args.yaml_output is not None:
+    #
+    #        # Merge si le fichier existe
+    #        if os.path.exists(args.yaml_output):
+    #            with open(args.yaml_output, 'r') as f:
+    #                existing_yaml = f.read()
+    #            final_yaml = merge_yaml_strings(existing_yaml, yanl)
+    #        else:
+    #            final_yaml = yanl
+    #
+    #        output_dir = os.path.dirname(args.yaml_output)
+    #        if output_dir:
+    #            os.makedirs(output_dir, exist_ok=True)
+    #
+    #        with open(args.yaml_output, 'w') as f:
+    #            f.write(final_yaml)
+    #
+    #        print(f"YAML config written to: {args.yaml_output}")
 
     if args.output is not None:
         print(hcl_files)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -301,7 +301,7 @@ def test_output_directory_without_slash(
 @patch(
     'builtins.open',
     new_callable=mock_open,
-    read_data="gke:\n  cluster:\n    enabled: true\n",
+    read_data="gke:\n  helper:\n    enabled: true\n",
 )
 def test_yaml_output_merge_if_exists(
     mock_open_read,
@@ -312,9 +312,10 @@ def test_yaml_output_merge_if_exists(
     tmp_path,
     capsys,
 ):
-    yaml_output_file = tmp_path / "config.yaml"
+    yaml_output_dir = tmp_path
+    yaml_filename = "config.test.yaml"
+    yaml_output_file = yaml_output_dir / yaml_filename
 
-    # Ajoute une variable optionnelle pour éviter IndexError dans content_next
     mock_read_dir.return_value = {
         'variable': [
             {
@@ -338,9 +339,11 @@ def test_yaml_output_merge_if_exists(
             '-v',
             '0.0.1',
             '-l',
-            'gke',
+            'gke.helper',
+            '--yaml-for-env',
+            'test',
             '--yaml-output',
-            str(yaml_output_file),
+            str(yaml_output_dir),
         ]
         main(args)
 
@@ -356,7 +359,7 @@ def test_yaml_output_merge_if_exists(
 @patch('generator.main.copy_terraform_module')
 @patch('generator.main.read_directory')
 @patch('os.makedirs')
-@patch('os.path.exists', return_value=False)  # 👈 le fichier n'existe PAS
+@patch('os.path.exists', return_value=False)
 @patch('builtins.open', new_callable=mock_open)
 def test_yaml_output_new_file_creation(
     mock_open_write,
@@ -367,9 +370,10 @@ def test_yaml_output_new_file_creation(
     tmp_path,
     capsys,
 ):
-    yaml_output_file = tmp_path / "config.yaml"
+    yaml_output_dir = tmp_path
+    yaml_filename = "config.dev.yaml"
+    yaml_output_file = yaml_output_dir / yaml_filename
 
-    # Une seule variable suffit ici
     mock_read_dir.return_value = {
         'variable': [
             {
@@ -390,8 +394,10 @@ def test_yaml_output_new_file_creation(
             '0.0.1',
             '-l',
             'gke',
+            '--yaml-for-env',
+            'dev',
             '--yaml-output',
-            str(yaml_output_file),
+            str(yaml_output_dir),
         ]
         main(args)
 


### PR DESCRIPTION
- Introduce new CLI argument --yaml-for-env to generate or merge YAML config files using the pattern `config.<env>.yaml`.
- Update `generate_locals` to optionally insert `local.environment` and dynamically build config file name using `format(...)`.
- Automatically determine YAML output path from --yaml-output + env suffix.
- Update CLI tests to verify the correct behavior of YAML merging and creation for specified environments.

Example:
  --yaml-for-env=dev --yaml-output=./ → generates or updates ./config.dev.yaml