### PR TITLE
feat: add --enabled flag to CLI and propagate to YAML generation

### DIFF
--- a/generator/generate.py
+++ b/generator/generate.py
@@ -15,6 +15,7 @@ def generate_header(
         'optionals': {},
         'nullables': {},
     },
+    enabled: bool = True,
 ) -> tuple[str, str]:
     lookup = lookup.replace('local.all', '')
     path = path or ''
@@ -27,7 +28,7 @@ def generate_header(
     else:
         lookup_prefix = lookup
 
-    yaml_raw = get_yaml(lookup, variables)
+    yaml_raw = get_yaml(lookup, variables, enabled)
     yaml_comment = yaml_raw.replace(f'{lookup_prefix}:', f'# {lookup_prefix}:').replace(
         '\n  ', '\n#   '
     )
@@ -200,6 +201,7 @@ def generate(
     name: str = None,
     config_filename: str = "config.yaml",
     yaml_env: str = None,
+    enabled: bool = True,
 ) -> tuple[str, str]:
     variables, variables_object = parse_variables(hcl_files['variable'])
 
@@ -209,7 +211,9 @@ def generate(
         else:
             name = os.path.dirname(url).split('/')[-1:][0].replace('.git', '')
 
-    header, yaml = generate_header(name, url, path, version, lookup, variables_object)
+    header, yaml = generate_header(
+        name, url, path, version, lookup, variables_object, enabled
+    )
     results: str
     results = header
     results += generate_include(include)

--- a/generator/main.py
+++ b/generator/main.py
@@ -57,6 +57,13 @@ parser.add_argument(
     default=None,
 )
 
+parser.add_argument(
+    '--enabled',
+    help='enabled module in configuration',
+    action=argparse.BooleanOptionalAction,
+    default=True,
+)
+
 
 def create_working_directory() -> str:
     tempdir = f'{gettempdir()}/{uuid4()}'
@@ -101,6 +108,7 @@ def main(args=None):
             )
         ),
         yaml_env=args.yaml_for_env,
+        enabled=args.enabled,
     )
 
     if args.yaml_output is not None:

--- a/generator/yaml.py
+++ b/generator/yaml.py
@@ -1,7 +1,7 @@
 import json
 
 
-def get_yaml(name: str, variables) -> str:
+def get_yaml(name: str, variables, is_enabled: bool = True) -> str:
     name_parts = name.split('.')
 
     indent = '  ' * len(name_parts)
@@ -31,7 +31,7 @@ def get_yaml(name: str, variables) -> str:
         nested_yaml += f"{current_indent}{part}:\n"
         current_indent += '  '
 
-    return f"""{nested_yaml}{current_indent}enabled: true
+    return f"""{nested_yaml}{current_indent}enabled: {"true" if is_enabled else "false"}
 {text}"""
 
 


### PR DESCRIPTION
- Introduced a `--enabled/--no-enabled` flag to the CLI to control whether the module is marked as enabled in the generated YAML.
- Passed the `enabled` parameter through `main`, `generate`, and `generate_header` functions.
- Updated `get_yaml` to conditionally output `enabled: true|false` based on this flag.
- Updated related unit tests to cover the new functionality.