### PR TITLE
feat(cli): support multiple --yaml-output and --yaml-for-env options

### DIFF
--- a/generator/yaml.py
+++ b/generator/yaml.py
@@ -1,16 +1,18 @@
 import json
 
 
+def format_description(description: str, indent: str) -> str:
+    lines = description.replace('\\"', '"').split('\n')
+    # if not lines:
+    #     return ''
+    formatted = lines[0]
+    if len(lines) > 1:
+        for line in lines[1:]:
+            formatted += f'\n{indent}# {line.lstrip()}'
+    return formatted
+
+
 def get_yaml(name: str, variables, is_enabled: bool = True) -> str:
-    def format_description(description: str, indent: str) -> str:
-        lines = description.replace('\\"', '"').split('\n')
-        if not lines:
-            return ''
-        formatted = lines[0]
-        if len(lines) > 1:
-            for line in lines[1:]:
-                formatted += f'\n{indent}# {line.lstrip()}'
-        return formatted
 
     name_parts = name.split('.')
     indent = '  ' * len(name_parts)

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,4 +1,40 @@
-from generator.yaml import get_yaml, merge_yaml_strings
+import pytest
+
+from generator.yaml import format_description, get_yaml, merge_yaml_strings
+
+
+@pytest.mark.parametrize(
+    "description, indent, expected",
+    [
+        (
+            'This is a description.',
+            '    ',
+            'This is a description.',
+        ),
+        (
+            'This is a description.\nWith a second line.',
+            '    ',
+            'This is a description.\n    # With a second line.',
+        ),
+        (
+            'First line.\nSecond line.\nThird line.',
+            '  ',
+            'First line.\n  # Second line.\n  # Third line.',
+        ),
+        (
+            '',
+            '    ',
+            '',
+        ),
+        (
+            'Line with \\"escaped\\" quotes.',
+            '    ',
+            'Line with "escaped" quotes.',
+        ),
+    ],
+)
+def test_format_description(description, indent, expected):
+    assert format_description(description, indent) == expected
 
 
 def test_get_yaml():


### PR DESCRIPTION
- Allow specifying multiple --yaml-output directories or files.
- Allow specifying multiple --yaml-for-env environments.
- Adapt writing logic to dynamically handle multiple YAML outputs with or without environment suffixes.
- Extracted HCL file writing to a dedicated write_hcl_file function.
- Refactored YAML writing logic to use pathlib for better path management.
- Added unit tests for new YAML output cases (file, directory, with/without env).
- Added format_description test for yaml formatting improvements.